### PR TITLE
fix: increase lint heap limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:e2e:run": "pkgmgr run test:e2e:run --silent --prefix playground",
     "setup": "pkgmgrx epicshop setup",
     "setup:custom": "node ./epicshop/setup-custom.js",
-    "lint": "eslint .",
+    "lint": "node --max-old-space-size=4096 ./node_modules/eslint/bin/eslint.js .",
     "format": "prettier --write .",
     "typecheck": "tsc -b",
     "validate:all": "npm-run-all --parallel --print-label --print-name --continue-on-error test:all lint typecheck"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- run ESLint through Node with a 4 GB old-space heap
- keep the lint command cross-platform for the setup matrix
- prevent the macOS setup job from aborting at Node's 2 GB default heap limit

## Validation

- `npm run lint`
- setup matrix passed on Ubuntu, macOS, and Windows
- solution tests passed
- post-merge Fly deploy and health check passed

CI: https://github.com/epicweb-dev/mcp-auth/actions/runs/30414986648
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6843ad5-8835-4a91-957a-9ca2957d22c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6843ad5-8835-4a91-957a-9ca2957d22c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

